### PR TITLE
[CT-6398] fix: don't keep looping if eos is reached

### DIFF
--- a/jinjasql/core.py
+++ b/jinjasql/core.py
@@ -68,6 +68,11 @@ class SqlExtension(Extension):
                     token = next(stream)
                 variable_end = token
 
+                if stream.eos:
+                    for token in var_expr:
+                        yield token
+                    return
+
                 last_token = var_expr[-1]
                 lineno = last_token.lineno
                 # don't bind twice

--- a/jinjasql/core.py
+++ b/jinjasql/core.py
@@ -63,7 +63,7 @@ class SqlExtension(Extension):
             token = next(stream)
             if token.test("variable_begin"):
                 var_expr = []
-                while not token.test("variable_end"):
+                while not stream.eos and not token.test("variable_end"):
                     var_expr.append(token)
                     token = next(stream)
                 variable_end = token


### PR DESCRIPTION
Otherwise we get in an endless loop if the query ends with {{ some_variable (without the closing }})