### PR TITLE
[CT-6398] fix(python-kernel): make interpolation work if ends in }}

### DIFF
--- a/jinjasql/core.py
+++ b/jinjasql/core.py
@@ -69,6 +69,7 @@ class SqlExtension(Extension):
                 variable_end = token
 
                 if stream.eos:
+                    var_expr.append(variable_end)
                     for token in var_expr:
                         yield token
                     return


### PR DESCRIPTION
We were not copying the last token of the stream (e.g.`}}`) and so it broke queries ending in `}}`