### PR TITLE
[CT-7485] fix: remove early exit from stream parsing

### DIFF
--- a/jinjasql/core.py
+++ b/jinjasql/core.py
@@ -66,14 +66,8 @@ class SqlExtension(Extension):
                 while not stream.eos and not token.test("variable_end"):
                     var_expr.append(token)
                     token = next(stream)
+                
                 variable_end = token
-
-                if stream.eos:
-                    var_expr.append(variable_end)
-                    for token in var_expr:
-                        yield token
-                    return
-
                 last_token = var_expr[-1]
                 lineno = last_token.lineno
                 # don't bind twice


### PR DESCRIPTION
This change allows the correct parsing of SQL queries that end with a variable like

```
SELECT *
FROM employees.employees
WHERE gender = {{ gender }}
```